### PR TITLE
Use correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=A simple RTC4543 library.
 paragraph=A simple Arduino library controling the rial time clock RTC-4543. This library is designed to easily access to the device from Arduino based board including tiny core based board and ESP8266.
 category=Device Control
 url=https://github.com/monoxit/RTC4543lib/
-architectures=avr,tiny,ESP8266
+architectures=avr,tiny,esp8266


### PR DESCRIPTION
When an ESP8266 board is selected the incorrect `architectures` value `ESP8266` causes the RTC4543lib example sketch to not appear in the **File > Examples** menu and the warning:
```
WARNING: library RTC4543lib-master claims to run on (avr, tiny, ESP8266) architecture(s) and may be incompatible with your current board which runs on (esp8266) architecture(s).
```
is shown during compilation.